### PR TITLE
Avoid decode undefined of path parameters

### DIFF
--- a/router.js
+++ b/router.js
@@ -25,7 +25,9 @@ module.exports = function router(app){
 
     if(!routes.length) return yield* next;// not found.
     var route = routes[ 0 ];
-    var args = route.regexp.exec(this.path).slice(1).map(decodeURIComponent);
+    var args = route.regexp.exec(this.path).slice(1).map(function(arg) {
+      return arg !== undefined ? decodeURIComponent(arg) : undefined; 
+    });
     route.regexp.keys.forEach(function(key, i){
       params[ key.name ] = args[ i ];
     });


### PR DESCRIPTION
path-to-regexp 支持可选参数 /path/:arg?，当可选参数不提供时，会得到 arg: undefined，然后
decodeURIComponent(undefined) 的结果是字符串 ‘undefined’
